### PR TITLE
Claim diff as the language module for git commit messages

### DIFF
--- a/diff.plist
+++ b/diff.plist
@@ -50,6 +50,10 @@
 			<string>.patch</string>
 		</dict>
 	</array>
+	<key>BBLMFileNamesToMatch</key>
+	<array>
+		<string>COMMIT_EDITMSG</string>
+	</array>
 	<key>Language Features</key>
 	<dict>
 		<key>Close Block Comments</key>


### PR DESCRIPTION
For use with verbose commit messages edited in BBEdit enabled by:
- `git config --global core.editor "bbedit -w"`
- `git config --global commit.verbose true`